### PR TITLE
Small fix for kompics 1.0.0-SNAPSHOT

### DIFF
--- a/core/src/main/java/se/sics/kompics/simulator/events/system/SetupEvent.java
+++ b/core/src/main/java/se/sics/kompics/simulator/events/system/SetupEvent.java
@@ -19,13 +19,9 @@
 
 package se.sics.kompics.simulator.events.system;
 
-import java.util.Set;
-import org.javatuples.Pair;
-import se.sics.kompics.network.Address;
 import se.sics.kompics.simulator.events.SimulationEvent;
 import se.sics.kompics.simulator.network.identifier.IdentifierExtractor;
 import se.sics.kompics.simulator.network.identifier.impl.SocketIdExtractor;
-import se.sics.kompics.simulator.util.GlobalViewHandler;
 import se.sics.kompics.simulator.util.GlobalView;
 
 /**

--- a/core/src/main/java/se/sics/kompics/simulator/util/GlobalView.java
+++ b/core/src/main/java/se/sics/kompics/simulator/util/GlobalView.java
@@ -21,7 +21,6 @@
 package se.sics.kompics.simulator.util;
 
 import java.util.Map;
-import java.util.Set;
 import se.sics.kompics.network.Address;
 import se.sics.kompics.simulator.network.identifier.Identifier;
 

--- a/core/src/main/java/se/sics/kompics/simulator/util/GlobalViewHandler.java
+++ b/core/src/main/java/se/sics/kompics/simulator/util/GlobalViewHandler.java
@@ -26,7 +26,7 @@ import se.sics.kompics.network.Msg;
 /**
  * @author Alex Ormenisan <aaor@sics.se>
  */
-public abstract class GlobalViewHandler<E extends KompicsEvent, M extends Msg & PatternExtractor<Class, E>> extends ClassMatchedHandler<E, M> {
+public abstract class GlobalViewHandler<E extends KompicsEvent, M extends Msg & PatternExtractor<Class<Object>, E>> extends ClassMatchedHandler<E, M> {
     private GlobalView simContext;
     
     public void setSimulationContext(GlobalView simContext) {


### PR DESCRIPTION
It's a tiny fix that makes the core simulator module to compile for kompics 1.0.0-snapshot